### PR TITLE
linkify meetup.com

### DIFF
--- a/dcrug/CodeOfConduct.md
+++ b/dcrug/CodeOfConduct.md
@@ -3,7 +3,7 @@
 DCRUG is dedicated to providing a safe and harassment-free experience for everyone, regardless of personal attributes such as gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion.
 We do not tolerate harassment of participants in any form.
 
-This code of conduct applies to any of our community interactions, including at meetups, on meetup.com, on our mailing list, on our forums, or any other DCRUG-sanctioned event or space.
+This code of conduct applies to any of our community interactions, including at meetups, on [meetup.com](http://www.meetup.com/dcruby/), on our mailing list, on our forums, or any other DCRUG-sanctioned event or space.
 
 If you have been or are being harassed by a member of the community, please contact one of the organizers either in person or through info@dcrug.org. We commit to taking swift action including up to expelling the offender from DCRUG and calling relevant authorities as needed.
 If a complaint is about an organizer, another organizer will resolve the complaint.


### PR DESCRIPTION
This PR makes the reference to meetup.com a link (to DCRUG), so people can more easily go find us if they should happen to stumble across the CoC out of context and not already be members.
